### PR TITLE
README.md updated dependency instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ sudo pip install -r requirements.txt
 >
 >Ubuntu
 >```sh
->sudo apt-get install python-scapy
+>sudo apt-get install python3-scapy
 >```
 >Arch Linux
 >```sh


### PR DESCRIPTION
When running sudo pip install -r requirements.txt normally, I get the error externally-managed-environment. pip recommends using pacman. Adding --break-system-packages works too but mixing pacman and pip packages is risky.