### PR TITLE
refactor: 💡 Ignore initial PS4 PPOE requests to increase the chances of the exploit working

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ make -C stage2 FW=1100 clean && make -C stage2 FW=1100
 
 For other firmwares, e.g. FW 9.00, pass `FW=900`.
 
-Run the exploit (see `ifconfig` for the correct interface):
+DO NOT RUN the exploit just yet (don't press Enter yet) but prepare this command on your prompt (see `ifconfig` for the correct interface):
 
 ```sh
 sudo python3 pppwn.py --interface=enp0s3 --fw=1100
@@ -66,11 +66,15 @@ On your PS4:
 - Enter anything for `PPPoE User ID` and `PPPoE Password`
 - Choose `Automatic` for `DNS Settings` and `MTU Settings`
 - Choose `Do Not Use` for `Proxy Server`
-- Click `Test Internet Connection` to communicate with your computer
 
-If the exploit fails or the PS4 crashes, you can skip the internet setup and simply click on `Test Internet Connection`. If the `pppwn.py` script is stuck waiting for a request/response, abort it and run it again on your computer, and then click on `Test Internet Connection` on your PS4.
+- Now, simultaneously press the 'X' button on your controler on `Test Internet Connection` and 'Enter' on your keyboard (on the computer you have your Python script ready to run).
 
-If the exploit works, you should see an output similar to below, and you should see `Cannot connect to network.` followed by `PPPwned` printed on your PS4.
+ALWAYS wait for you console to show the message "Cannot connect to network: (NW-31274-7)" before trying this PPOE injection again.
+
+If the exploit fails or the PS4 crashes, you can skip the internet setup and simply click on `Test Internet Connection`. Kill the `pppwn.py` script and run it again on your computer, and then click on `Test Internet Connection` on your PS4: always simultaneously.
+
+
+If the exploit works, you should see an output similar to below, and you should see `Cannot connect to network.` followed by `PPPwned` printed on your PS4, or the other way around. 
 
 ### Example run
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ On your PS4:
 - Choose `Automatic` for `DNS Settings` and `MTU Settings`
 - Choose `Do Not Use` for `Proxy Server`
 
-- Now, simultaneously press the 'X' button on your controler on `Test Internet Connection` and 'Enter' on your keyboard (on the computer you have your Python script ready to run).
+- Now, simultaneously press the 'X' button on your controller on `Test Internet Connection` and 'Enter' on your keyboard (on the computer you have your Python script ready to run).
 
 ALWAYS wait for you console to show the message "Cannot connect to network: (NW-31274-7)" before trying this PPOE injection again.
 

--- a/pppwn.py
+++ b/pppwn.py
@@ -259,7 +259,16 @@ class Exploit():
                              id=pkt[PPP_IPCP].id,
                              options=pkt[PPP_IPCP].options))
 
-    def ppp_negotation(self, cb=None):
+    def ppp_negotation(self, cb=None, ignore_initial_reqs=False):
+        if ignore_initial_reqs: # Ignore initial requests in order to increase the chances of the exploit working
+            num_reqs_to_ignore = 6 # Tested from 6 to 8 on version 10.50 - all give best results then not ignoring
+            num_ignored_reqs = 0
+            print('[*] Ignoring initial {} PS4 requests..'.format(num_reqs_to_ignore))
+            while num_ignored_reqs < num_reqs_to_ignore:
+                pkt = self.s.recv()
+                num_ignored_reqs+=1
+                print(num_ignored_reqs)
+            print('[*] Continuing...')
         print('[*] Waiting for PADI...')
         while True:
             pkt = self.s.recv()
@@ -609,7 +618,7 @@ class Exploit():
         print('')
         print('[+] STAGE 0: Initialization')
 
-        self.ppp_negotation(self.build_fake_ifnet)
+        self.ppp_negotation(self.build_fake_ifnet, True)
         self.lcp_negotiation()
         self.ipcp_negotiation()
 

--- a/pppwn.py
+++ b/pppwn.py
@@ -260,18 +260,16 @@ class Exploit():
                              options=pkt[PPP_IPCP].options))
 
     def ppp_negotation(self, cb=None, ignore_initial_reqs=False):
-        if ignore_initial_reqs: # Ignore initial requests in order to increase the chances of the exploit working
-            num_reqs_to_ignore = 6 # Tested from 6 to 8 on version 10.50 - all give best results then not ignoring
-            num_ignored_reqs = 0
-            print('[*] Ignoring initial {} PS4 requests..'.format(num_reqs_to_ignore))
-            while num_ignored_reqs < num_reqs_to_ignore:
-                pkt = self.s.recv()
-                num_ignored_reqs+=1
-                print(num_ignored_reqs)
-            print('[*] Continuing...')
+        num_reqs_to_ignore = 6  # Ignore initial requests in order to increase the chances of the exploit to work
+                                # Tested from 6 to 8 requests, on version 10.50 - all give best results then not ignoring
+        num_ignored_reqs = 0
         print('[*] Waiting for PADI...')
         while True:
             pkt = self.s.recv()
+            if ignore_initial_reqs and (num_ignored_reqs < num_reqs_to_ignore):
+                print('[*] Ignoring initial PS4 PPoE request #{}..'.format(num_ignored_reqs+1))
+                num_ignored_reqs+=1
+                continue
             if pkt and pkt.haslayer(
                     PPPoED) and pkt[PPPoED].code == PPPOE_CODE_PADI:
                 break


### PR DESCRIPTION
**Tested on firmware 10.50 - Model CUH-1102A, Debian 11 with IPV6 enabled (might IPV4 only be a problem?)**
My initial tests showed that it would fail 80% of the time but be successful eventually - Great job there for all of you involved! Making it work is a masterpiece! I really appreciate you effort and envy your talent.

Without discarding the first requests of PPPoe from the PS4, the injection would fail the first 5x and work twice after that.  And reset after it.
Discarding 6 to 8 from the first attempts from the PS4 shown very effective, at least in the version of the system I have. 
Discarding 6 packages shown to make to glitch work on the first time, every time..  
Waiting for the popup  "Cannot connect to network: (NW-31274-7)"  is very important between tests..
 