### PR TITLE
Sending LCP terminate request after failing in the stage1

### DIFF
--- a/pppwn.py
+++ b/pppwn.py
@@ -747,6 +747,10 @@ class Exploit():
 
         if not corrupted:
             print('[-] Scanning for corrupted object...failed. Please retry.')
+            self.s.send(
+                Ether(
+                    src=self.source_mac, dst=self.target_mac, type=ETHERTYPE_PPPOE)
+                / PPPoE(sessionid=self.SESSION_ID) / PPP() / PPP_LCP_Terminate())
             exit(1)
 
         print(


### PR DESCRIPTION
This can make `NW-31274-7` appear within 5 seconds, avoiding waiting for more than one minute. (Tested on 9.0)

For me personally, I would directly wait for 5s and then rerun it. However, it may be too aggressive, so I didn't put it in this PR. (It runs stably for me).

```diff
if not corrupted:
    print('[-] Scanning for corrupted object...failed. Please retry.')
    self.s.send(
        Ether(
            src=self.source_mac, dst=self.target_mac, type=ETHERTYPE_PPPOE)
        / PPPoE(sessionid=self.SESSION_ID) / PPP() / PPP_LCP_Terminate())
+   sleep(5)
+   self.run()
    exit(1)
```
