### PR TITLE
add -fpic flag because some gcc instances do not default to pic code

### DIFF
--- a/stage1/Makefile
+++ b/stage1/Makefile
@@ -3,7 +3,7 @@ OBJS = start.o stage1.o
 
 CC = gcc
 OBJCOPY = objcopy
-CFLAGS = -DSMP -isystem ../freebsd-headers/include -Wl,--build-id=none -Os -fno-stack-protector
+CFLAGS = -DSMP -isystem ../freebsd-headers/include -Wl,--build-id=none -Os -fno-stack-protector -fpic
 LDFLAGS = -T linker.ld -nostartfiles -nostdlib
 
 ifneq ($(filter $(FW), 750 751 755 800 801 803 850 852 900 903 904 950 951 960 1000 1001 1050 1070 1071 1100),)

--- a/stage2/Makefile
+++ b/stage2/Makefile
@@ -3,7 +3,7 @@ OBJS = start.o stage2.o
 
 CC = gcc
 OBJCOPY = objcopy
-CFLAGS = -DSMP -isystem ../freebsd-headers/include -Wl,--build-id=none -Os -fno-stack-protector
+CFLAGS = -DSMP -isystem ../freebsd-headers/include -Wl,--build-id=none -Os -fno-stack-protector -fpic
 LDFLAGS = -T linker.ld -nostartfiles -nostdlib
 
 ifneq ($(filter $(FW), 750 751 755 800 801 803 850 852 900 903 904 950 951 960 1000 1001 1050 1070 1071 1100),)


### PR DESCRIPTION
gcc generates funky stuff like `mov r9d, 0x137` instead of `lea r9, ...` which causes crashes