### PR TITLE
Removed `pwd=$(pwd)` b/c it is unnecessary

### DIFF
--- a/build-macarm.sh
+++ b/build-macarm.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 DESIREDVER=${1-1100}
 echo "Building for $DESIREDVER . To use another PS4 Firwmare Version, execute this script as so: $0 <version>"
-pwd=$(pwd)
 docker build  --build-arg="PS4FWVER=$DESIREDVER" -t pppwn-docker . --platform linux/amd64
-docker run -v "$pwd:/host" pppwn-docker
+docker run -v "$(pwd):/host" pppwn-docker
 mv stage1.bin stage1
 mv stage2.bin stage2


### PR DESCRIPTION
The script only uses the pwd variable once so it’s not needed to create a whole variable just for the one usage